### PR TITLE
Fix socket connection fail message bug

### DIFF
--- a/web/src/components/pnlData/index.js
+++ b/web/src/components/pnlData/index.js
@@ -11,9 +11,11 @@ export const PnlData = () => {
   const channel = dateFormat(new Date(), 'yyyymmdd')
   const socket = '127.0.0.1:3001'
   const ws = useRef(new WebSocket(`ws://${socket}/ws/sub/${channel}`)).current
+  const [isConnected, setIsConnected] = useState(false)
 
   useEffect(() => {
     const handleOpen = () => {
+      setIsConnected(true)
       toast.success('Connection to the server established successfully!')
     }
 
@@ -27,10 +29,14 @@ export const PnlData = () => {
 
     const handleError = () => {
       toast.error("Can't establish connection to the server!")
+      setIsConnected(false)
     }
 
     const handleClose = () => {
-      toast.warn('Connection to the server has been terminated!')
+      if (isConnected) {
+        toast.warn('Connection to the server has been terminated!')
+        setIsConnected(false)
+      }
     }
 
     ws.addEventListener('open', handleOpen)
@@ -45,7 +51,7 @@ export const PnlData = () => {
       ws.removeEventListener('close', handleClose)
       ws.close()
     }
-  }, [ws])
+  }, [])
 
   const scrollToBottom = () => {
     if (bottomRef.current) {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Security Fix
- [x] Bug Fix
- [x] Optimization
- [ ] Documentation Update
- [ ] Dependency Update

## Description

Only "*Can't establish connection to the server!*" message should be shown when socket connection fails to be initialized.

## Related Tickets & Documents

- Closes #36 

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: _testing not utilized at this point_
- [ ] I need help with writing tests